### PR TITLE
Modify .bashrc and .bash_profile to prepare for UPS to slack transition.

### DIFF
--- a/dotFiles/.bash_profile
+++ b/dotFiles/.bash_profile
@@ -7,7 +7,6 @@
 #
 if [ -f "${HOME}/.bashrc" ]; then
     source "${HOME}/.bashrc"
-    export BASH_ENV="${HOME}/.bashrc"
 fi
 #
 # If you wish to add your own configuration we recommend you do so in

--- a/dotFiles/.bash_profile
+++ b/dotFiles/.bash_profile
@@ -1,24 +1,18 @@
 # .bash_profile file for use by Mu2e accounts at Fermilab
-#
+#     See: https://mu2ewiki.fnal.gov/wiki/Shells#Setup_scripts
+##
 # This file will be sourced at the start of all login shells.
 #
-# Intialize a the common UPS repository (common to all experiments)
-#
-upsfile="/cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups.sh"
-if [  -r "${upsfile}" ]; then
-    . "${upsfile}"
-fi
-unset upsfile
-#
-# User configuration for login shells:
-#
-if [ -f "${HOME}/.my_bash_profile" ]; then
-    source "${HOME}/.my_bash_profile"
-fi
-#
-# User configuration for non-login shells.
+# Include configuration common to login and non-login shells.
 #
 if [ -f "${HOME}/.bashrc" ]; then
     source "${HOME}/.bashrc"
     export BASH_ENV="${HOME}/.bashrc"
+fi
+#
+# If you wish to add your own configuration we recommend you do so in
+# .my_bash_profile so that there is a clean separation concerns.
+#
+if [ -f "${HOME}/.my_bash_profile" ]; then
+    source "${HOME}/.my_bash_profile"
 fi

--- a/dotFiles/.bashrc
+++ b/dotFiles/.bashrc
@@ -6,9 +6,14 @@
 # but not login shells.  We recommend that you source it in .bash_profile
 # so that it is also effective for login shells.
 #
-# Alias to create the Mu2e working environment in a shell.
+
+# Make sure that all subshells get this environment.
+export BASH_ENV="${HOME}/.bashrc"
+
+# Alias to create the Mu2e working environment in the current shell.
 alias mu2einit="source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"
 
+# Some recommended safety settings.
 case "$-" in
 *i*)	# These commands executed for interactive shells
         set -o noclobber            #prevent overwrite when redirecting output

--- a/dotFiles/.bashrc
+++ b/dotFiles/.bashrc
@@ -1,4 +1,5 @@
 # Example .bashrc file for use by Mu2e accounts at Fermilab
+#
 #     See: https://mu2ewiki.fnal.gov/wiki/Shells#Setup_scripts
 #
 # This file will be sourced at the start of all shells that are interactive
@@ -6,7 +7,7 @@
 # so that it is also effective for login shells.
 #
 # Alias to create the Mu2e working environment in a shell.
-alias setup-mu2e="source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"
+alias mu2einit="source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"
 
 case "$-" in
 *i*)	# These commands executed for interactive shells
@@ -18,7 +19,7 @@ case "$-" in
 esac
 
 #
-# system configuration - required to get jobsub and other Fermi supplied
+# system configuration - required to get jobsub and other Fermi supplied software.
 #
 if [ -f "/etc/bashrc" ]; then
     source "/etc/bashrc"

--- a/dotFiles/.bashrc
+++ b/dotFiles/.bashrc
@@ -1,8 +1,13 @@
 # Example .bashrc file for use by Mu2e accounts at Fermilab
+#     See: https://mu2ewiki.fnal.gov/wiki/Shells#Setup_scripts
 #
 # This file will be sourced at the start of all shells that are interactive
-# but not login shells (unless you source it in your .bash_profile).
+# but not login shells.  We recommend that you source it in .bash_profile
+# so that it is also effective for login shells.
 #
+# Alias to create the Mu2e working environment in a shell.
+alias setup-mu2e=". /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"
+
 case "$-" in
 *i*)	# These commands executed for interactive shells
         set -o noclobber            #prevent overwrite when redirecting output
@@ -13,13 +18,14 @@ case "$-" in
 esac
 
 #
-# system configuration
+# system configuration - required to get jobsub and other Fermi supplied
 #
 if [ -f "/etc/bashrc" ]; then
     source "/etc/bashrc"
 fi
 #
-# user configuration
+# If you wish to add your own configuration we recommend you do so in
+# .my_bashrc so that there is a clean separation of concerns.
 #
 if [ -f "${HOME}/.my_bashrc" ]; then
     source "${HOME}/.my_bashrc"

--- a/dotFiles/.bashrc
+++ b/dotFiles/.bashrc
@@ -6,7 +6,7 @@
 # so that it is also effective for login shells.
 #
 # Alias to create the Mu2e working environment in a shell.
-alias setup-mu2e=". /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"
+alias setup-mu2e="source /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"
 
 case "$-" in
 *i*)	# These commands executed for interactive shells


### PR DESCRIPTION
This PR makes changes to the Mu2e recommended versions of .bashrc and .bash_profile to prepare for the retrirement of UPS.  The main change is that the UPS setup of products/common is replaced with the definition of an alias:

> alias setup-mu2e=". /cvmfs/mu2e.opensciencegrid.org/setupmu2e-art.sh"

This is now present only in .bashrc because that is sourced from .bash_profile.  It needs to be present in .bashrc because many ways of connecting to the interactive machines create non-login shells.

I also cleaned up some comments.
